### PR TITLE
Use non-binary patching to work around different line endings than we expect.

### DIFF
--- a/targets/repository.proj
+++ b/targets/repository.proj
@@ -43,7 +43,7 @@
 
     <PropertyGroup>
       <PatchCommand Condition="'$(IsJenkinsBuild)' == 'true'">git apply --ignore-whitespace --whitespace=nowarn</PatchCommand>
-      <PatchCommand Condition="'$(IsJenkinsBuild)' != 'true'">patch -p1 --ignore-whitespace --binary -i</PatchCommand>
+      <PatchCommand Condition="'$(IsJenkinsBuild)' != 'true'">patch -p1 --ignore-whitespace -i</PatchCommand>
     </PropertyGroup>
 
     <Exec Command="$(PatchCommand) %(PatchesToApply.Identity)"


### PR DESCRIPTION
People can have different git `core.eol` and `core.autocrlf` settings, and default git behavior has changed over time, which causes problems when we attempt to patch in binary mode.  This changes makes us patch in text mode instead, which handles differing line endings.