### PR TITLE
Add intermediate source path for corefx GenApi.  

### DIFF
--- a/build-source-tarball.sh
+++ b/build-source-tarball.sh
@@ -152,6 +152,9 @@ cp -r $SCRIPT_ROOT/bin/obj/x64/Release/reference-packages/packages $TARBALL_ROOT
 cp -r $SCRIPT_ROOT/bin/obj/x64/Release/reference-packages/source $TARBALL_ROOT/reference-packages/source
 cp -r $SCRIPT_ROOT/bin/obj/x64/Release/reference-packages/staging $TARBALL_ROOT/reference-packages/staging
 
+# Copy generated source from bin to src/generatedSrc
+cp -r $SCRIPT_ROOT/bin/obj/x64/Release/generatedSrc $TARBALL_ROOT/src/generatedSrc
+
 if [ -e $SCRIPT_ROOT/testing-smoke/smoke-test-packages ]; then
     cp -rf $SCRIPT_ROOT/testing-smoke/smoke-test-packages $TARBALL_ROOT/prebuilt
 fi

--- a/build.proj
+++ b/build.proj
@@ -28,6 +28,8 @@
     <MakeDir Directories="$(LocalBlobStorageRoot)" />
     <MakeDir Directories="$(MSBuildDebugPathTargetDir)" />
     <MakeDir Directories="$(RoslynDebugPathTargetDir)" />
+    <MakeDir Condition="'$(OfflineBuild)' != 'true'" Directories="$(GeneratedSourcePathOnline)" />
+    <MakeDir Condition="'$(OfflineBuild)' == 'true'" Directories="$(GeneratedSourcePathOffline)" />
   </Target>
 
   <Target Name="InitBuild">

--- a/dir.props
+++ b/dir.props
@@ -63,6 +63,8 @@
     <BaseIntermediatePath>$(BaseOutputPath)obj/</BaseIntermediatePath>
     <OutputPath>$(BaseOutputPath)$(Platform)/$(Configuration)/</OutputPath>
     <IntermediatePath>$(BaseIntermediatePath)$(Platform)/$(Configuration)/</IntermediatePath>
+    <GeneratedSourcePathOnline>$(IntermediatePath)generatedSrc</GeneratedSourcePathOnline>
+    <GeneratedSourcePathOffline>$(SubmoduleDirectory)generatedSrc</GeneratedSourcePathOffline>
     <LocalBlobStorageRoot>$(IntermediatePath)blobs/</LocalBlobStorageRoot>
     <LocalBuildInfoRoot>$(IntermediatePath)build-info/</LocalBuildInfoRoot>
     <LocalNuGetPackagesRoot>$(IntermediatePath)nuget-packages/</LocalNuGetPackagesRoot>

--- a/repos/corefx.proj
+++ b/repos/corefx.proj
@@ -29,7 +29,8 @@
     <BuildArguments>$(BuildArguments) /p:EnableSourceLink=false</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:EnableVSTestReferences=false</BuildArguments>
     <BuildArguments>$(BuildArguments) /p:ILLinkTrimAssembly=false</BuildArguments>
-    <BuildArguments>$(BuildArguments) /p:DotNetSourceBuildIntermediatePath=$(IntermediatePath)</BuildArguments>
+    <BuildArguments Condition="'$(OfflineBuild)' != 'true'">$(BuildArguments) /p:DotNetSourceBuildIntermediatePath=$(GeneratedSourcePathOnline)</BuildArguments>
+    <BuildArguments Condition="'$(OfflineBuild)' == 'true'">$(BuildArguments) /p:DotNetSourceBuildIntermediatePath=$(GeneratedSourcePathOffline)</BuildArguments>
     <BuildArguments Condition="'$(TargetOS)' == 'OSX'">$(BuildArguments) /p:MicrosoftNetCoreIlasmPackageRuntimeId=$(OverrideTargetRid)</BuildArguments>
 
     <LogVerbosityOptOut>true</LogVerbosityOptOut>


### PR DESCRIPTION
Path is under bin/obj/x64/Release/generatedSrc for Online build, which populates the
source.  Path is moved to src/generatedSrc for tarball build.